### PR TITLE
Fix bug when monkey patching plt.Figure, and apply facecolor when using plt.savefig

### DIFF
--- a/qbstyles/mpl_style.py
+++ b/qbstyles/mpl_style.py
@@ -91,7 +91,7 @@ def _monkey_patch_figure(color, Figure):
 
     def _patch(*args, **kwargs):
         fig = Figure(*args, **kwargs)
-        _style_ticks(fig.gca, color)
+        _style_ticks(fig.gca(), color)
         return fig
 
     return _patch

--- a/qbstyles/styles/qb-dark.mplstyle
+++ b/qbstyles/styles/qb-dark.mplstyle
@@ -19,4 +19,5 @@ legend.edgecolor : FFFFFFD9 # legend edge color (when 'inherit' uses axes.edgeco
 
 ### FIGURE
 #TODO: notebook ignores this
-figure.facecolor : 0C1C23    # figure facecolor; 0.75 is scalar gray
+figure.facecolor : 0C1C23    # figure facecolor
+savefig.facecolor : 0C1C23    # figure facecolor

--- a/qbstyles/styles/qb-light.mplstyle
+++ b/qbstyles/styles/qb-light.mplstyle
@@ -20,3 +20,4 @@ legend.edgecolor : 000000D9 # legend edge color (when 'inherit' uses axes.edgeco
 ### FIGURE
 #figure.facecolor : 0.75    # figure facecolor; 0.75 is scalar gray
 figure.facecolor: FFFFFF
+savefig.facecolor: FFFFFF


### PR DESCRIPTION
Currently, when monkey patching to apply minor ticks, instead of obtaining the matplotlib axis object we obtain the callable that returns the axis.

This is a minimal example to reproduce the bug:

```python
import matplotlib.pyplot as plt
from qbstyles import mpl_style
mpl_style(dark=True)
fig = plt.Figure()
```