### PR TITLE
Fixed various issues, added support for the latest MPL 3.4.*

### DIFF
--- a/qbstyles/__init__.py
+++ b/qbstyles/__init__.py
@@ -18,4 +18,4 @@ This module contains QB styles for common plotting libraries such as matplotlib.
 
 from .mpl_style import mpl_style
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"

--- a/qbstyles/mpl_style.py
+++ b/qbstyles/mpl_style.py
@@ -36,6 +36,8 @@ LIGHT_STYLE = "qb-light.mplstyle"
 
 __all__ = ["mpl_style"]
 
+original_subplots = plt.subplots
+original_figure = plt.figure
 
 def mpl_style(dark: bool = True, minor_ticks: bool = True):
     """Some of the tick properties cannot be set using ``plt.style.use``.
@@ -65,10 +67,12 @@ def mpl_style(dark: bool = True, minor_ticks: bool = True):
         for style in [COMMON_STYLE, DARK_STYLE if dark else LIGHT_STYLE]
     )
     color = "FFFFFF" if dark else "000000"
-
     if minor_ticks:
-        plt.subplots = _monkey_patch_subplot(color, plt.subplots)
-        plt.Figure = _monkey_patch_figure(color, plt.Figure)
+        plt.subplots = _monkey_patch_subplot(color, original_subplots)
+        plt.figure = _monkey_patch_figure(color, original_figure)
+    else:
+        plt.subplots = original_subplots
+        plt.figure = original_figure
 
 
 def _style_ticks(axis, color):
@@ -85,12 +89,12 @@ def _style_ticks(axis, color):
         tick.set_color("#" + color + "3D")
 
 
-def _monkey_patch_figure(color, Figure):
+def _monkey_patch_figure(color, figure):
     """ Style a figure's current axis tick marks, just after the figure is
     created. """
 
     def _patch(*args, **kwargs):
-        fig = Figure(*args, **kwargs)
+        fig = figure(*args, **kwargs)
         _style_ticks(fig.gca(), color)
         return fig
 


### PR DESCRIPTION
This fix should solve three main problems: 

1. Critical bug when using MPL 3.4.*  because of broken duck typing (see screenshot below). 
2. Issue when after using `minor_ticks=True` it is impossible to switch back in the following `mpl_style` calls 
3. Multiple calls of `mpl_style` will create multiple patch wrappers which potentially can impact app performance


<img width="1089" alt="Screenshot 2021-10-25 at 21 41 14" src="https://user-images.githubusercontent.com/4551081/138767745-467674db-41af-442f-a9d0-7c54c12fcc7c.png">

 